### PR TITLE
contentswrite

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,7 @@
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
<!--
DBスキーマの更新がある場合はAuto-mergeを有効化しないこと。
　merge前に本番環境のDBスキーマの更新が必要なため。
