### PR TITLE
graphql updateBasicInformation

### DIFF
--- a/graphql/schema/basic_information.graphqls
+++ b/graphql/schema/basic_information.graphqls
@@ -1,0 +1,9 @@
+input UpdateBasicInformationInput {
+  birthday: Date
+  gender: Gender
+  academicBackground: String
+}
+
+type UpdateBasicInformationPayload {
+  basicInformation: BasicInformation!
+}

--- a/graphql/schema/directive.graphqls
+++ b/graphql/schema/directive.graphqls
@@ -1,0 +1,1 @@
+directive @admin on FIELD_DEFINITION

--- a/graphql/schema/schema.graphqls
+++ b/graphql/schema/schema.graphqls
@@ -3,6 +3,10 @@ type Query {
   node(id: ID!): Node
 }
 
+type Mutation {
+  updateBasicInformation(input: UpdateBasicInformationInput!): UpdateBasicInformationPayload @admin
+}
+
 interface Node {
   id: ID!
 }


### PR DESCRIPTION
<!--
DBスキーマの更新がある場合はAuto-mergeを有効化しないこと。
　merge前に本番環境のDBスキーマの更新が必要なため。
